### PR TITLE
更改字体目录获取逻辑

### DIFF
--- a/nodes/add_watermark.py
+++ b/nodes/add_watermark.py
@@ -32,6 +32,7 @@ def add_image_watermark(original, watermark, x, y, opacity, scale):
 def add_text_watermark(original, text, x, y, scale, opacity, color, fonts):
     txt = Image.new('RGBA', original.size, (255, 255, 255, 0))
     font_path = get_font_path()
+    font_path = os.path.join(font_path, fonts)
     font_size = int(40 * scale)
     font = ImageFont.truetype(font_path, font_size)
     d = ImageDraw.Draw(txt)

--- a/nodes/add_watermark.py
+++ b/nodes/add_watermark.py
@@ -5,6 +5,10 @@ import folder_paths
 import os
 
 
+def get_font_path():
+    return os.path.join(os.path.dirname(os.path.dirname(__file__)), 'fonts')
+
+
 def tensor2pil(t_image: torch.Tensor) -> Image:
     return Image.fromarray(np.clip(255.0 * t_image.cpu().numpy().squeeze(), 0, 255).astype(np.uint8))
 
@@ -27,9 +31,7 @@ def add_image_watermark(original, watermark, x, y, opacity, scale):
 
 def add_text_watermark(original, text, x, y, scale, opacity, color, fonts):
     txt = Image.new('RGBA', original.size, (255, 255, 255, 0))
-    font_path = os.path.join(folder_paths.get_output_directory(), 'ComfyUI-MingNodes', 'fonts')
-    font_path = font_path.replace("output", "custom_nodes")
-    font_path = os.path.join(font_path, fonts)
+    font_path = get_font_path()
     font_size = int(40 * scale)
     font = ImageFont.truetype(font_path, font_size)
     d = ImageDraw.Draw(txt)
@@ -49,8 +51,7 @@ def hex_to_rgb(hex_color):
 class AddWaterMarkNode:
     @classmethod
     def INPUT_TYPES(s):
-        font_path = os.path.join(folder_paths.get_output_directory(), 'ComfyUI-MingNodes', 'fonts')
-        font_path = font_path.replace("output", "custom_nodes")
+        font_path = get_font_path()
         files = [f for f in os.listdir(font_path) if os.path.isfile(os.path.join(font_path, f))]
 
         return {


### PR DESCRIPTION
我指定了ComfyUI启动时的output目录（`-output-directory Z:\output`），会导致获取字体目录异常，见下：
```
[ERROR] An error occurred while retrieving information for the 'AddWaterMarkNode' node.
Traceback (most recent call last):
  File "D:\ComfyUI\server.py", line 564, in get_object_info
    out[x] = node_info(x)
             ^^^^^^^^^^^^
  File "D:\ComfyUI\server.py", line 531, in node_info
    info['input'] = obj_class.INPUT_TYPES()
                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ComfyUI\custom_nodes\ComfyUI-MingNodes\nodes\add_watermark.py", line 54, in INPUT_TYPES
    files = [f for f in os.listdir(font_path) if os.path.isfile(os.path.join(font_path, f))]
                        ^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 3] 系统找不到指定的路径。: 'Z:\\custom_nodes\\ComfyUI-MingNodes\\fonts'
```

该提交修改了获取字体目录的逻辑。